### PR TITLE
removed pinned numpy from sumgram

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "Operating System :: OS Independent"
     ],
     install_requires=[
-        'numpy==1.17.0',
+        'numpy',
         'requests==2.22.0',
         'sklearn==0.0'
     ],


### PR DESCRIPTION
This should address #27 by removing the pinned `numpy` version in `setup.py`